### PR TITLE
Typo in morse potential documentation

### DIFF
--- a/docs/src/RigidRotor.md
+++ b/docs/src/RigidRotor.md
@@ -16,10 +16,11 @@ and the Hamiltonian
 ```math
 \begin{aligned}
   \hat{H} &= - \frac{\hbar^2}{2\mu} \nabla^2 + V(r), \\
-          &= - \frac{\hbar^2}{2I} \left[ \frac{1}{\sin\theta} \frac{\partial}{\partial\theta} \left(\sin\theta \frac{\partial}{\partial\theta}\right) + \frac{1}{\sin^2\theta} \frac{\partial^2}{\partial\phi^2}  \right]
+          &= - \frac{\hbar^2}{2I} \left[ \frac{1}{\sin\theta} \frac{\partial}{\partial\theta} \left(\sin\theta \frac{\partial}{\partial\theta}\right) + \frac{1}{\sin^2\theta} \frac{\partial^2}{\partial\phi^2}  \right], \\
+          &= \frac{L^2}{2I}
 \end{aligned}
 ```
-where $I=\mu R^2$ is the moment of intertia, $\mu=\left(\frac{1}{m_1}+\frac{1}{m_2}\right)^{-1}$ is the reduced mass of two particles and $R$ is the distance between the two particles. Parameters are specified with the following struct.
+where $I=\mu R^2$ is the moment of intertia, $\mu=\left(\frac{1}{m_1}+\frac{1}{m_2}\right)^{-1}$ is the reduced mass of two particles, $R$ is the distance between the two particles, and $L^2$ is the angular momentum operator. Parameters are specified with the following struct.
 
 #### Parameters
 ```@docs; canonical=false
@@ -50,6 +51,11 @@ Antique.Y(::RigidRotor, ::Any, ::Any)
 ```@docs; canonical=false
 Antique.P(::RigidRotor, ::Any)
 ```
+
+#### References
+- Anderson, J.M. Introduction to Quantum Chemistry, 1969, W.A. Benjamin, Inc, p.91-100
+- [Chemistry Libre Texts](https://chem.libretexts.org/Bookshelves/Physical_and_Theoretical_Chemistry_Textbook_Maps/Physical_Chemistry_(LibreTexts)/05%3A_The_Harmonic_Oscillator_and_the_Rigid_Rotor/5.08%3A_The_Energy_Levels_of_a_Rigid_Rotor)
+
 
 ## Usage & Examples
 

--- a/test/MorsePotential.jl
+++ b/test/MorsePotential.jl
@@ -122,10 +122,10 @@ println(raw"""
 ```math
   \begin{aligned}
     E_n
-    &=      \int \psi^\ast_n(r) \hat{H} \psi_n(r) \mathrm{d}x \\
-    &=      \int \psi^\ast_n(r) \left[ \hat{V} + \hat{T} \right] \psi(r) \mathrm{d}x \\
-    &=      \int \psi^\ast_n(r) \left[ V(r) - \frac{\hbar^2}{2m} \frac{\mathrm{d}^{2}}{\mathrm{d} r^{2}} \right] \psi(r) \mathrm{d}x \\
-    &\simeq \int \psi^\ast_n(r) \left[ V(r)\psi(r) -\frac{\hbar^2}{2m} \frac{\psi(r+\Delta r) - 2\psi(r) + \psi(r-\Delta r)}{\Delta r^{2}} \right] \mathrm{d}x.
+    &=      \int \psi^\ast_n(r) \hat{H} \psi_n(r) \mathrm{d}r \\
+    &=      \int \psi^\ast_n(r) \left[ \hat{V} + \hat{T} \right] \psi(r) \mathrm{d}r \\
+    &=      \int \psi^\ast_n(r) \left[ V(r) - \frac{\hbar^2}{2m} \frac{\mathrm{d}^{2}}{\mathrm{d} r^{2}} \right] \psi(r) \mathrm{d}r \\
+    &\simeq \int \psi^\ast_n(r) \left[ V(r)\psi(r) -\frac{\hbar^2}{2m} \frac{\psi(r+\Delta r) - 2\psi(r) + \psi(r-\Delta r)}{\Delta r^{2}} \right] \mathrm{d}r.
   \end{aligned}
 ```
 

--- a/test/result/MorsePotential.log
+++ b/test/result/MorsePotential.log
@@ -785,10 +785,10 @@
 ```math
   \begin{aligned}
     E_n
-    &=      \int \psi^\ast_n(r) \hat{H} \psi_n(r) \mathrm{d}x \\
-    &=      \int \psi^\ast_n(r) \left[ \hat{V} + \hat{T} \right] \psi(r) \mathrm{d}x \\
-    &=      \int \psi^\ast_n(r) \left[ V(r) - \frac{\hbar^2}{2m} \frac{\mathrm{d}^{2}}{\mathrm{d} r^{2}} \right] \psi(r) \mathrm{d}x \\
-    &\simeq \int \psi^\ast_n(r) \left[ V(r)\psi(r) -\frac{\hbar^2}{2m} \frac{\psi(r+\Delta r) - 2\psi(r) + \psi(r-\Delta r)}{\Delta r^{2}} \right] \mathrm{d}x.
+    &=      \int \psi^\ast_n(r) \hat{H} \psi_n(r) \mathrm{d}r \\
+    &=      \int \psi^\ast_n(r) \left[ \hat{V} + \hat{T} \right] \psi(r) \mathrm{d}r \\
+    &=      \int \psi^\ast_n(r) \left[ V(r) - \frac{\hbar^2}{2m} \frac{\mathrm{d}^{2}}{\mathrm{d} r^{2}} \right] \psi(r) \mathrm{d}r \\
+    &\simeq \int \psi^\ast_n(r) \left[ V(r)\psi(r) -\frac{\hbar^2}{2m} \frac{\psi(r+\Delta r) - 2\psi(r) + \psi(r-\Delta r)}{\Delta r^{2}} \right] \mathrm{d}r.
   \end{aligned}
 ```
 


### PR DESCRIPTION
 Just a small typo in the formula dx -> dr for computing eigenenergy. 