### PR TITLE
Bump version to 0.12.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Antique"
 uuid = "be6e5d0e-34a5-4c8f-af83-e1b5389203d8"
 authors = ["Shuhei Ohno"]
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Antique.jl provides self-contained, well-tested, and well-documented implementat
 Run the following code on the REPL to install this package.
 
 ```julia
-]add Antique@0.12.0
+]add Antique@0.12.1
 ```
 
-Or run `import Pkg; Pkg.add(; name="Antique", version="0.12.0")` to install on Jupyter Notebook. The version of this package can be found at `]status Antique` or `import Pkg; Pkg.status("Antique")`.
+Or run `import Pkg; Pkg.add(; name="Antique", version="0.12.1")` to install on Jupyter Notebook. The version of this package can be found at `]status Antique` or `import Pkg; Pkg.status("Antique")`.
 
 ## Usage & Examples
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,10 +15,10 @@ Antique.jl provides self-contained, well-tested, and well-documented implementat
 Run the following code on the REPL to install this package.
 
 ```julia
-]add Antique@0.12.0
+]add Antique@0.12.1
 ```
 
-Or run `import Pkg; Pkg.add(; name="Antique", version="0.12.0")` to install on Jupyter Notebook. The version of this package can be found at `]status Antique` or `import Pkg; Pkg.status("Antique")`.
+Or run `import Pkg; Pkg.add(; name="Antique", version="0.12.1")` to install on Jupyter Notebook. The version of this package can be found at `]status Antique` or `import Pkg; Pkg.status("Antique")`.
 
 ## Usage & Examples
 


### PR DESCRIPTION
Due to a long interruption, we should release the current version as v0.12.1 before resuming work. I will solve the issues based on this version since now.